### PR TITLE
Adds maximum size to main window to disallow maximizing

### DIFF
--- a/tumpasrc/__init__.py
+++ b/tumpasrc/__init__.py
@@ -466,6 +466,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setWindowTitle("Tumpa")
         self.setMinimumWidth(600)
         self.setMinimumHeight(575)
+        self.setMaximumWidth(600)
+        self.setMaximumHeight(575)
         self.ks = jce.KeyStore("./")
         self.vboxlayout_for_keys = QtWidgets.QVBoxLayout()
         self.widget = KeyWidgetList(self.ks)


### PR DESCRIPTION
Adding both minimum and maximum dimesnions allows us to fix the dimension, hence disallowing maximizing of the window (and hence breaking the UI)